### PR TITLE
Use Modern gamepad layout with default controller

### DIFF
--- a/game.libretro.prboom/resources/buttonmap.xml
+++ b/game.libretro.prboom/resources/buttonmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-  <controller id="game.controller.default" type="RETRO_DEVICE_JOYPAD">
+  <controller id="game.controller.default" type="RETRO_DEVICE_ANALOG" subclass="2">
     <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
     <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
     <feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>

--- a/game.libretro.prboom/resources/buttonmap.xml
+++ b/game.libretro.prboom/resources/buttonmap.xml
@@ -15,6 +15,10 @@
     <feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
     <feature name="lefttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
     <feature name="righttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
+    <feature name="leftthumb" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
+    <feature name="rightthumb" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
+    <feature name="leftstick" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT"/>
+    <feature name="rightstick" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT"/>
   </controller>
   <controller id="game.controller.mouse" type="RETRO_DEVICE_MOUSE">
     <feature name="left" mapto="RETRO_DEVICE_ID_MOUSE_LEFT"/>


### PR DESCRIPTION
The default Kodi controller is based on the xbox 360 and has analog sticks support, so it makes more sense for it to use the modern gamepad layout supported by this core, rather than the classic layout that does not make use of the analogs.

Fixes #7 